### PR TITLE
Remove aws sdk 2

### DIFF
--- a/bin/create_cron_leader
+++ b/bin/create_cron_leader
@@ -4,7 +4,6 @@ require           'optparse'
 require           'rubygems'
 gem               'aws-sdk-v1'
 require           'aws-sdk-v1'
-require           'aws-sdk'
 require           'erb'
 
 EB_CONFIG_APP_SUPPORT = "/opt/elasticbeanstalk/support"

--- a/bin/ensure_one_cron_leader
+++ b/bin/ensure_one_cron_leader
@@ -3,7 +3,6 @@
 require           'rubygems'
 gem               'aws-sdk-v1'
 require           'aws-sdk-v1'
-require           'aws-sdk'
 require           'erb'
 
 EB_CONFIG_APP_SUPPORT = "/opt/elasticbeanstalk/support"

--- a/bin/remove_cron_leader
+++ b/bin/remove_cron_leader
@@ -3,7 +3,6 @@
 require           'rubygems'
 gem               'aws-sdk-v1'
 require           'aws-sdk-v1'
-require           'aws-sdk'
 require           'erb'
 
 EB_CONFIG_APP_SUPPORT = "/opt/elasticbeanstalk/support"

--- a/bin/setup_cron
+++ b/bin/setup_cron
@@ -3,7 +3,6 @@
 require           'rubygems'
 gem               'aws-sdk-v1'
 require           'aws-sdk-v1'
-require           'aws-sdk'
 require           'erb'
 
 EB_CONFIG_APP_SUPPORT = "/opt/elasticbeanstalk/support"

--- a/bin/setup_cron
+++ b/bin/setup_cron
@@ -21,4 +21,4 @@ unless (`echo $PATH`).match("/usr/local/bin")
 end
 
 roles = ec2.instances[instance_id].tags["leader"].eql?("true") ? ["leader", ENVIRONMENT] : ["non-leader"]
-`/usr/local/bin/bundle exec whenever --roles #{roles.join(',')} --set 'environment=#{ENVIRONMENT}&path=/var/app/current' --update-crontab --user root`
+`/usr/local/bin/bundle exec whenever --roles #{roles.join(',')} --set 'environment=#{ENVIRONMENT}&path=/var/app/current' --update-crontab`

--- a/bin/setup_cron
+++ b/bin/setup_cron
@@ -21,4 +21,4 @@ unless (`echo $PATH`).match("/usr/local/bin")
 end
 
 roles = ec2.instances[instance_id].tags["leader"].eql?("true") ? ["leader", ENVIRONMENT] : ["non-leader"]
-`./bin/whenever --roles #{roles.join(',')} --set 'environment=#{ENVIRONMENT}&path=/var/app/current' --update-crontab --user root`
+`/usr/local/bin/bundle exec whenever --roles #{roles.join(',')} --set 'environment=#{ENVIRONMENT}&path=/var/app/current' --update-crontab --user root`

--- a/bin/setup_cron
+++ b/bin/setup_cron
@@ -21,4 +21,4 @@ unless (`echo $PATH`).match("/usr/local/bin")
 end
 
 roles = ec2.instances[instance_id].tags["leader"].eql?("true") ? ["leader", ENVIRONMENT] : ["non-leader"]
-`/usr/local/bin/bundle exec whenever --roles #{roles.join(',')} --set 'environment=#{ENVIRONMENT}&path=/var/app/current' --update-crontab`
+`/usr/local/bin/bundle exec whenever --roles #{roles.join(',')} --set 'environment=#{ENVIRONMENT}&path=/var/app/current' --update-crontab  --user root`

--- a/bin/setup_cron
+++ b/bin/setup_cron
@@ -21,4 +21,4 @@ unless (`echo $PATH`).match("/usr/local/bin")
 end
 
 roles = ec2.instances[instance_id].tags["leader"].eql?("true") ? ["leader", ENVIRONMENT] : ["non-leader"]
-`/usr/local/bin/bundle exec whenever --roles #{roles.join(',')} --set 'environment=#{ENVIRONMENT}&path=/var/app/current' --update-crontab  --user root`
+`/usr/local/bin/bundle exec whenever --roles #{roles.join(',')} --set 'environment=#{ENVIRONMENT}&path=/var/app/current' --update-crontab --user root`

--- a/bin/wheneverize-eb
+++ b/bin/wheneverize-eb
@@ -80,65 +80,18 @@ files:
     group: root
     content: |
       #!/usr/bin/env bash
-      # /opt/elasticbeanstalk/hooks/appdeploy/post/10_reload_cron.sh
-
-      if test -d /opt/elasticbeanstalk/containerfiles; then
-        . /opt/elasticbeanstalk/containerfiles/envvars
-      elif test -d /opt/elasticbeanstalk/support; then
-        . /opt/elasticbeanstalk/support/envvars
-      fi
-      
-      su -l -c "cd $EB_CONFIG_APP_CURRENT && /usr/local/bin/bundle exec setup_cron" $EB_CONFIG_APP_USER
-  # Add Bundle to the PATH
-  "/etc/profile.d/bundle.sh":
-    mode: "000755"
-    owner: root
-    group: root
-    content: |
-      #!/usr/bin/env bash
-      export PATH=$PATH:/usr/local/bin
-    encoding: plain
-  # Update /opt/elasticbeanstalk/###/envvars.d/appenv to include EB_CONFIG_SUPPORT
-  /tmp/update_appenv_include_eb_config_support.sh:
-    mode: "000755"
-    owner: root
-    group: root
-    content: |
-      #!/usr/bin/env bash
-      # update_appenv_include_eb_config_support.sh
-      if test -d /opt/elasticbeanstalk/containerfiles; then
-        echo "containerfiles"
-        grep -Fwq "export EB_CONFIG_SUPPORT" /opt/elasticbeanstalk/containerfiles/envvars.d/appenv
-        if [ $? -eq 1 ]; then
-          echo "export EB_CONFIG_SUPPORT=/opt/elasticbeanstalk/containerfiles"
-          echo "export EB_CONFIG_SUPPORT=/opt/elasticbeanstalk/containerfiles" >> /opt/elasticbeanstalk/containerfiles/envvars.d/appenv;
-        fi
-      elif test -d /opt/elasticbeanstalk/support; then
-        echo "support"
-        grep -Fwq "export EB_CONFIG_SUPPORT" /opt/elasticbeanstalk/support/envvars.d/appenv
-        if [ $? -eq 1 ]; then
-          echo "export EB_CONFIG_SUPPORT=/opt/elasticbeanstalk/support"
-          echo "export EB_CONFIG_SUPPORT=/opt/elasticbeanstalk/support" >> /opt/elasticbeanstalk/support/envvars.d/appenv;
-        fi
-      fi
-    encoding: plain
+      su -l -s /bin/bash -c "cd $(/opt/elasticbeanstalk/bin/get-config container -k app_deploy_dir) && /usr/local/bin/bundle exec setup_cron" $(/opt/elasticbeanstalk/bin/get-config container -k app_user)
 commands:
   create_bundle_symlink_patch:
     test: test ! -f /usr/local/bin/bundle
-    command: ln -s `su -l -c "which bundle" $EB_CONFIG_APP_USER` /usr/local/bin/bundle
-    ignoreErrors: true
-  a_elasticbeanstalk_support_path:
-    command: . /tmp/update_appenv_include_eb_config_support.sh
-    ignoreErrors: false
-  zz_check_support_path_environment_variable:
-    command: echo $EB_SUPPORT
+    command: ln -s `su -l -c "which bundle" $(/opt/elasticbeanstalk/bin/get-config container -k app_user)` /usr/local/bin/bundle
     ignoreErrors: true
 container_commands:
   cron_01_set_leader:
     test: test ! -f /opt/elasticbeanstalk/containerfiles/.cron-setup-complete || test ! -f /opt/elasticbeanstalk/support/.cron-setup-complete
     leader_only: true
     cwd: /var/app/ondeck
-    command: su -c "/usr/local/bin/bundle exec create_cron_leader --no-update" $EB_CONFIG_APP_USER
+    command: su -l -s /bin/bash -c "/usr/local/bin/bundle exec create_cron_leader --no-update" $(/opt/elasticbeanstalk/bin/get-config container -k app_user)
   cron_02_write_cron_setup_complete_file_containerfiles:
     test: test -d /opt/elasticbeanstalk/containerfiles
     command: touch /opt/elasticbeanstalk/containerfiles/.cron-setup-complete

--- a/bin/wheneverize-eb
+++ b/bin/wheneverize-eb
@@ -80,11 +80,21 @@ files:
     group: root
     content: |
       #!/usr/bin/env bash
-      su -l -s /bin/bash -c "cd $(/opt/elasticbeanstalk/bin/get-config container -k app_deploy_dir) && /usr/local/bin/bundle exec setup_cron" $(/opt/elasticbeanstalk/bin/get-config container -k app_user)
+      # Loading environment data
+      EB_SCRIPT_DIR=$(/opt/elasticbeanstalk/bin/get-config container -k script_dir)
+      EB_SUPPORT_DIR=$(/opt/elasticbeanstalk/bin/get-config container -k support_dir)
+      EB_APP_CURRENT_DIR=$(/opt/elasticbeanstalk/bin/get-config container -k app_deploy_dir)
+
+      # Setting up correct environment and ruby version so that bundle can load all gems
+      . $EB_SUPPORT_DIR/envvars
+      . $EB_SCRIPT_DIR/use-app-ruby.sh
+
+      cd $EB_APP_CURRENT_DIR
+      /usr/local/bin/bundle exec setup_cron
 commands:
   create_bundle_symlink_patch:
     test: test ! -f /usr/local/bin/bundle
-    command: ln -s `su -l -c "which bundle" $(/opt/elasticbeanstalk/bin/get-config container -k app_user)` /usr/local/bin/bundle
+    command: ln -s `su -l -s /bin/bash -c "which bundle" $(/opt/elasticbeanstalk/bin/get-config container -k app_user)` /usr/local/bin/bundle
     ignoreErrors: true
 container_commands:
   cron_01_set_leader:


### PR DESCRIPTION
You had added the `aws-sdk-v1` but there were still some vestiges of the `aws-sdk` gem that I removed.  I also updated the `cron.config` file to work with the new environment variables.
